### PR TITLE
Fix publication missing pom file.

### DIFF
--- a/deploy.gradle
+++ b/deploy.gradle
@@ -1,9 +1,20 @@
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
+
+publishing {
+    publications {
+        SemverPublication(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+        }
+    }
+}
 
 bintray {
     user = project.findProperty('bintrayUser') ?: System.getenv('BINTRAY_USER')
     key = project.findProperty('bintrayKey') ?: System.getenv('BINTRAY_KEY')
-    configurations = ['archives']
+    publications = ['SemverPublication']
     dryRun = true
     publish = true
     override = true


### PR DESCRIPTION
Switched bintray publication from configuration type to maven publication.

To test run `./gradlew publishToMavenLocal`, then check `~/.m2/repository/net/swiftzer/semver/semver/1.1.0/` - it should contain all publication artifacts, pom as well.

Fixes #2.